### PR TITLE
chore(provider): remove redundant aws provider

### DIFF
--- a/provider.tf
+++ b/provider.tf
@@ -1,6 +1,0 @@
-# empty provider definitiom has to be here because of this issue in terraform
-# https://github.com/hashicorp/terraform/issues/28490
-
-provider "aws" {
-  alias = "destination"
-}


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change, provide a justification and which issue is fixed.
-->

Specifying AWS provider alias via additional provider block is not needed anymore. Tested with Terraform 1.5.

## How Has This Been Tested?

I was getting following waning
```
│ Warning: Redundant empty provider block
│
│   on .terraform/modules/cloudtrail/provider.tf line 4:
│    4: provider "aws" {
│
│ Earlier versions of Terraform used empty provider blocks ("proxy provider configurations") for child modules to declare their need to be passed a provider configuration by their callers. That approach was
│ ambiguous and is now deprecated.
│
│ If you control this module, you can migrate to the new declaration syntax by removing all of the empty provider "aws" blocks and then adding or updating an entry like the following to the
│ required_providers block of module.cloudtrail:
│     aws = {
│       source = "hashicorp/aws"
│       configuration_aliases = [
│         aws.destination,
│       ]
│     }
```
after removal of the redundant provider is it not present anymore. Tested with Terraform 1.5.

<!--
Please describe the tests that you ran to verify your changes.
-->
